### PR TITLE
Use endsWith for checking if using goimports

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -289,7 +289,7 @@ class Formatter {
     let cursor = editor.getCursorBufferPosition()
     let args = ['-e']
     if (filePath) {
-      if (formatCmd.startsWith('goimports')) {
+      if (formatCmd.endsWith('goimports')) {
         args.push('--srcdir')
         args.push(path.dirname(filePath))
       }


### PR DESCRIPTION
`formatCmd` will be a full path such as "/Users/yhat/gopath/bin/goimports" and as such endsWith, not startsWith, correctly checks for the usage of this tool.

This resolves #11.
