### PR TITLE
Use asynchronous exec to eliminate freeze on save

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -319,14 +319,22 @@ class Formatter {
       }
     }
 
-    let r = config.executor.execSync(cmd, args, options)
-    if (r.stderr && r.stderr.trim() !== '') {
-      console.log('gofmt: (stderr) ' + r.stderr)
-      return
-    }
-    if (r.exitcode === 0) {
-      editor.getBuffer().setTextViaDiff(r.stdout)
-    }
+    let promise = config.executor.exec(cmd, args, options)
+    promise.then(function(r) {
+      if (r.stderr && r.stderr.trim() !== '') {
+        console.log('gofmt: (stderr) ' + r.stderr)
+        return
+      }
+
+      if (r.exitcode !== 0) {
+        return
+      }
+
+      if (r.stdout != editor.getBuffer().getText()) {
+        editor.getBuffer().setTextViaDiff(r.stdout)
+        editor.getBuffer().save()
+      }
+    })
   }
 }
 export {Formatter}

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -320,7 +320,7 @@ class Formatter {
     }
 
     let promise = config.executor.exec(cmd, args, options)
-    promise.then(function(r) {
+    promise.then((r) => {
       if (r.stderr && r.stderr.trim() !== '') {
         console.log('gofmt: (stderr) ' + r.stderr)
         return
@@ -330,7 +330,7 @@ class Formatter {
         return
       }
 
-      if (r.stdout != editor.getBuffer().getText()) {
+      if (r.stdout !== editor.getBuffer().getText()) {
         editor.getBuffer().setTextViaDiff(r.stdout)
         editor.getBuffer().save()
       }


### PR DESCRIPTION
Currently if you're using the goreturns or goimports format tools, Atom can freeze for significant amounts of time. For one of my projects, saving completely freezes Atom for ~600 ms, which makes Atom feel slow.

This is due to the fact that the format tools are executed by synchronous operations, which this pull request has changed to be asynchronous so that Atom doesn't freeze while saving. The only downside to this is that any edits made in this short time frame while the formatter is being run will be lost, but I think it's worth the sacrifice to make Atom feel smoother.
